### PR TITLE
chore: bump sentry cli to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "4.6.2"
   },
   "dependencies": {
-    "@sentry/cli": "1.74.2"
+    "@sentry/cli": "2.1.0"
   },
   "peerDependencies": {
     "vite": "^2.8.6"


### PR DESCRIPTION
Sentry cli 1.7.2 requires npmlog^4.1.2 which is fairly old. 

Changelog to new entry major: https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md

As far as I can see is the only change that uploadSourceMap now uses rewrite as default. However, I don't see that as an issue? 