### PR TITLE
Allow @sentry/cli ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "4.7.3"
   },
   "dependencies": {
-    "@sentry/cli": "2.1.0"
+    "@sentry/cli": "^2.2.0"
   },
   "peerDependencies": {
     "vite": "^2.9.12"


### PR DESCRIPTION
I noticed that @sentry/cli has new version, however in this package version is strictly locked.
Intention of the PR is to allow flexible sentry versions within minor versions 