### PR TITLE
Reference types path to support moduleResolution: bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./dist/index.mjs",
     "default": "./dist/index.js"
   },


### PR DESCRIPTION
When switching tsconfig `moduleResolution` to `bundler`, `vite-plugin-sentry` gives this error:

Could not find a declaration file for module 'vite-plugin-sentry'. 'project/node_modules/vite-plugin-sentry/dist/index.mjs' implicitly has an 'any' type. There are types at 'project/node_modules/vite-plugin-sentry/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vite-plugin-sentry' library may need to update its package.json or typings.

This is because the new `bundler` option respects package.json `exports` instead of implicitly inferring declaration file. So `types` field has to be added to support this.

Context on `exports`: https://nodejs.org/api/packages.html#community-conditions-definitions
Context on `bundler`: https://github.com/microsoft/TypeScript/pull/51669