### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "vite-plugin-sentry",
   "description": "The unofficial Sentry plugin for Vite ⚡️",
   "version": "1.4.1",
+  "bugs": {
+    "url": "https://github.com/ikenfin/vite-plugin-sentry/issues"
+  },
   "author": "ikenfin",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.